### PR TITLE
Add an r8.im clone command

### DIFF
--- a/pkg/cli/clone.go
+++ b/pkg/cli/clone.go
@@ -1,0 +1,52 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/spf13/cobra"
+
+	"github.com/anotherjesse/r8im/pkg/auth"
+	"github.com/anotherjesse/r8im/pkg/images"
+)
+
+func newCloneCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "clone",
+		Short:  "copy existing image to a new image",
+		Hidden: false,
+		RunE:   cloneCommmand,
+	}
+
+	cmd.Flags().StringVarP(&sToken, "token", "t", "", "replicate cog token")
+	cmd.Flags().StringVarP(&sRegistry, "registry", "r", "r8.im", "registry host")
+	cmd.Flags().StringVarP(&baseRef, "base", "b", "", "base image reference - include tag: r8.im/username/modelname@sha256:hexdigest")
+	cmd.MarkFlagRequired("base")
+	cmd.Flags().StringVarP(&dest, "dest", "d", "", "destination image reference: r8.im/username/modelname")
+	cmd.MarkFlagRequired("dest")
+
+	return cmd
+}
+
+func cloneCommmand(cmd *cobra.Command, args []string) error {
+	if sToken == "" {
+		sToken = os.Getenv("COG_TOKEN")
+	}
+
+	u, err := auth.VerifyCogToken(sRegistry, sToken)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "authentication error, invalid token or registry host error")
+		return err
+	}
+	auth := authn.FromConfig(authn.AuthConfig{Username: u, Password: sToken})
+
+	image_id, err := images.Affix(baseRef, dest, "", auth)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(image_id)
+
+	return nil
+}

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -18,6 +18,7 @@ func NewRootCommand() (*cobra.Command, error) {
 
 	rootCmd.AddCommand(
 		newAffixCommand(),
+		newCloneCommand(),
 		newLayerCommand(),
 		newExtractCommand(),
 		newRemixCommand(),


### PR DESCRIPTION
this is used to create a copy of a public image for debugging purposes.

I'm tired of doing this gist: https://gist.github.com/bfirsh/a161ec388afc561b8682b10ce1653a50

I have to wait for it to download & expand the original image before I can push a clone to test if a model works on A40 or ...

Also useful to move models between orgs and users